### PR TITLE
Remove "private repo" note from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Utility to evaluate [BODMAS](https://en.wikipedia.org/wiki/Order_of_operations) 
 
 ### Installation
 
-**Note:** Since this is a private repository, you will need to authenticate your connection to GitHub, for example via [ssh](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh).
-
 ```
 yarn add beyondessential/arithmetic
 ```


### PR DESCRIPTION
Now that it's public - we don't really need it!