### PR TITLE
Add function support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ Operator | Example | Description
 `*` or `x` | `1 * 1` or `1 x 1` | Multiplication
 `/` | `1 / 1` | Division
 `()`| `1 / (1 + 1)` | Brackets
-`u` or `-` | `u1` or `-1` | Unary minus
+`-` | `-1` | Unary minus
 `max` | `max(1, 2, 3)` | Takes the maximum value of it's arguments. `-Infinity` if given none

--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ import { getVariables } from '@beyondessential/arithmetic';
 const variables = getVariables('(-a * b - 1) / (c + 3)');
 console.log(variables); // ['a', 'b', 'c']
 ```
+
+## formulaText operators
+Name | Example | Name
+-|-|-
+ `+` | `1 + 1` | Addition
+ `-` | `1 - 1` | Subtraction
+`*` or `x` | `1 * 1` or `1 x 1` | Multiplication
+`/` | `1 / 1` | Division
+`()`| `1 / (1 + 1)` | Brackets
+`u` or `-` | `u1` or `-1` | Unary minus
+`max` | `max(1, 2, 3)` | Takes the maximum value of it's arguments. `-Infinity` if given none

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ console.log(variables); // ['a', 'b', 'c']
 ```
 
 ## formulaText operators
-Name | Example | Name
+Note: All operators are case **in**sensitive.
+Operator | Example | Description
 -|-|-
  `+` | `1 + 1` | Addition
  `-` | `1 - 1` | Subtraction

--- a/__tests__/arithmetic.test.js
+++ b/__tests__/arithmetic.test.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 import { runArithmetic } from '../src/arithmetic';
 
 describe('Arithmetic', () => {

--- a/__tests__/arithmetic.test.js
+++ b/__tests__/arithmetic.test.js
@@ -96,7 +96,7 @@ describe('Arithmetic', () => {
     });
   });
 
-  describe.only('max function', () => {
+  describe('max function', () => {
     it('should handle max of one number', () => {
       const result = runArithmetic('max(15)');
       expect(result).toEqual(15);

--- a/__tests__/arithmetic.test.js
+++ b/__tests__/arithmetic.test.js
@@ -131,10 +131,10 @@ describe('Arithmetic', () => {
       );
     });
 
-    // it('should be caps insensitive', () => {
-    //   const result = runArithmetic('maX(15)');
-    //   expect(result).toEqual(15);
-    // });
+    it('should be caps insensitive', () => {
+      const result = runArithmetic('maX(15)');
+      expect(result).toEqual(15);
+    });
   });
 
   describe('substituting values', () => {

--- a/__tests__/arithmetic.test.js
+++ b/__tests__/arithmetic.test.js
@@ -187,6 +187,18 @@ describe('Arithmetic', () => {
       expect(() => runArithmetic('4 * 1 + 2)')).toThrow();
     });
 
+    it('should fail on incorrect function call', () => {
+      expect(() => runArithmetic('max(')).toThrow();
+      expect(() => runArithmetic('max())')).toThrow();
+      expect(() => runArithmetic('max(()')).toThrow();
+      expect(() => runArithmetic('max((1, 2), 3)')).toThrow();
+      expect(() => runArithmetic('max(3, (1, 2))')).toThrow();
+      expect(() => runArithmetic('max(, 3)')).toThrow();
+      expect(() => runArithmetic('max(3, )')).toThrow();
+      expect(() => runArithmetic('max(3,,2)')).toThrow();
+      expect(() => runArithmetic('max(3-,2)')).toThrow();
+    });
+
     it('should fail if a substitution is not numeric', () => {
       expect(() => runArithmetic('check + 1', { check: 'check' })).toThrow();
       expect(() => runArithmetic('check + 1', { check: '+' })).toThrow();

--- a/__tests__/arithmetic.test.js
+++ b/__tests__/arithmetic.test.js
@@ -97,6 +97,11 @@ describe('Arithmetic', () => {
   });
 
   describe('max function', () => {
+    it('should handle max with no arguments', () => {
+      const result = runArithmetic('max()');
+      expect(result).toEqual(-Infinity);
+    });
+
     it('should handle max of one number', () => {
       const result = runArithmetic('max(15)');
       expect(result).toEqual(15);

--- a/__tests__/arithmetic.test.js
+++ b/__tests__/arithmetic.test.js
@@ -124,7 +124,7 @@ describe('Arithmetic', () => {
 
     it('should handle a yet more complex expression', () => {
       const result = runArithmetic(
-        'max(1 + (-max(15, 3 - 2, -100) / 2 + 1 - max(2, 3/2)) /2, -10)',
+        'max(1 + (-max(15, 3 - 2, -100) / 2 + 1 - max(3/2, 2)) /2, -10)',
       );
       expect(result).toEqual(
         Math.max(1 + (-Math.max(15, 3 - 2, -100) / 2 + 1 - Math.max(2, 3 / 2)) / 2, -10),
@@ -168,7 +168,7 @@ describe('Arithmetic', () => {
     });
 
     it('should be able to substitute values into a function with the same name', () => {
-      const result = runArithmetic('maX(max, eyes)', VALUES);
+      const result = runArithmetic('max(max, eyes)', VALUES);
       expect(result).toEqual(Math.max(100, 10));
     });
   });

--- a/__tests__/arithmetic.test.js
+++ b/__tests__/arithmetic.test.js
@@ -96,6 +96,47 @@ describe('Arithmetic', () => {
     });
   });
 
+  describe.only('max function', () => {
+    it('should handle max of one number', () => {
+      const result = runArithmetic('max(15)');
+      expect(result).toEqual(15);
+    });
+
+    it('should handle max of two numbers', () => {
+      const result = runArithmetic('max(15, 20)');
+      expect(result).toEqual(20);
+    });
+
+    it('should handle max of more than two numbers', () => {
+      const result = runArithmetic('max(15, 12, 15.01, -100)');
+      expect(result).toEqual(15.01);
+    });
+
+    it('should handle a more complex expression', () => {
+      const result = runArithmetic('max(3 - 2, -100) / 2');
+      expect(result).toEqual(0.5);
+    });
+
+    it('should handle an even more complex expression', () => {
+      const result = runArithmetic('max(15, 3 - 2, -100) / 2 + 1 - max(2, 3/2)');
+      expect(result).toEqual(Math.max(15, 3 - 2, -100) / 2 + 1 - Math.max(2, 3 / 2));
+    });
+
+    it('should handle a yet more complex expression', () => {
+      const result = runArithmetic(
+        'max(1 + (-max(15, 3 - 2, -100) / 2 + 1 - max(2, 3/2)) /2, -10)',
+      );
+      expect(result).toEqual(
+        Math.max(1 + (-Math.max(15, 3 - 2, -100) / 2 + 1 - Math.max(2, 3 / 2)) / 2, -10),
+      );
+    });
+
+    // it('should be caps insensitive', () => {
+    //   const result = runArithmetic('maX(15)');
+    //   expect(result).toEqual(15);
+    // });
+  });
+
   describe('substituting values', () => {
     const VALUES = {
       fingers: 10,
@@ -103,6 +144,7 @@ describe('Arithmetic', () => {
       pi: 3.14159,
       sins: 7,
       negative: -5,
+      max: 100,
     };
 
     it('should handle simple value substitution', () => {
@@ -118,6 +160,16 @@ describe('Arithmetic', () => {
     it('should handle a more complicated case', () => {
       const result = runArithmetic('-eyes * (sins - pi * 3) / negative + (sins + 1)', VALUES);
       expect(result).toEqual((-2 * (7 - 3.14159 * 3)) / -5 + (7 + 1));
+    });
+
+    it('should handle substitution of a value which is a function name', () => {
+      const result = runArithmetic('fingers + max', VALUES);
+      expect(result).toEqual(10 + 100);
+    });
+
+    it('should be able to substitute values into a function with the same name', () => {
+      const result = runArithmetic('maX(max, eyes)', VALUES);
+      expect(result).toEqual(Math.max(100, 10));
     });
   });
 

--- a/__tests__/symbols.test.js
+++ b/__tests__/symbols.test.js
@@ -18,6 +18,11 @@ describe('getVariables()', () => {
     ['no whitespace', 'a+b', ['a', 'b']],
     ['same variable multiple times', 'a * b + a', ['a', 'b']],
     ['all operators', '(a + -b) / ((2 * c) - 3 x d)', ['a', 'b', 'c', 'd']],
+    ['formula includes functions', 'max(1, 2, a)', ['a']],
+    // TODO: The below fail (should they?)
+    //['variable with function name', 'max(1, 2, a, max)', ['a', 'max']],
+    //['TODO -fails', 'x-1', ['x']], // fix this in separate pr
+    //['TODO -fails', 'x - 1', ['x']], // fix this in separate pr
   ];
 
   it.each(testData)('%s', (_, formula, expected) => {

--- a/__tests__/symbols.test.js
+++ b/__tests__/symbols.test.js
@@ -20,9 +20,6 @@ describe('getVariables()', () => {
     ['all operators', '(a + -b) / ((2 * c) - 3 x d)', ['a', 'b', 'c', 'd']],
     ['formula includes functions', 'max(1, 2, a)', ['a']],
     ['variable with function name', 'max(1, 2, a, max)', ['a', 'max']],
-    // TODO: The below fail (should they?)
-    //['TODO -fails', 'x-1', ['x']], // fix this in separate pr
-    //['TODO -fails', 'x - 1', ['x']], // fix this in separate pr
   ];
 
   it.each(testData)('%s', (_, formula, expected) => {

--- a/__tests__/symbols.test.js
+++ b/__tests__/symbols.test.js
@@ -19,8 +19,8 @@ describe('getVariables()', () => {
     ['same variable multiple times', 'a * b + a', ['a', 'b']],
     ['all operators', '(a + -b) / ((2 * c) - 3 x d)', ['a', 'b', 'c', 'd']],
     ['formula includes functions', 'max(1, 2, a)', ['a']],
+    ['variable with function name', 'max(1, 2, a, max)', ['a', 'max']],
     // TODO: The below fail (should they?)
-    //['variable with function name', 'max(1, 2, a, max)', ['a', 'max']],
     //['TODO -fails', 'x-1', ['x']], // fix this in separate pr
     //['TODO -fails', 'x - 1', ['x']], // fix this in separate pr
   ];

--- a/src/arithmetic.js
+++ b/src/arithmetic.js
@@ -160,6 +160,11 @@ function processQueue(queue) {
 
 const noWhitespace = /\s/g;
 
+// Variables are not replaced if the next non-whitespace character is a '('
+// e.g. max(5 + max)
+// the first max would not be replaced as it is a function
+const buildVariableReplacer = (key) => new RegExp(`${key}(?!\\s*\\()`, 'g');
+
 export function runArithmetic(formulaText, values = {}) {
   // first replace variables with their actual values
   // (we do this here rather than treating the variable names as tokens,
@@ -172,7 +177,7 @@ export function runArithmetic(formulaText, values = {}) {
     }
 
     //TODO:
-    valuedText = valuedText.replace(new RegExp(key, 'g'), value);
+    valuedText = valuedText.replace(buildVariableReplacer(key), value);
   });
 
   // strip out all whitespace

--- a/src/arithmetic.js
+++ b/src/arithmetic.js
@@ -74,7 +74,7 @@ function shuntingYard(text) {
       continue;
     }
     if (token === ',') {
-      while (shouldPopOperator(token, stack[0])) {
+      while (stack.length && stack[0] !== '(') {
         queue.push(stack.shift());
       }
       if (!(stack[0] === '(' && isFunctionToken(stack[1]))) {

--- a/src/arithmetic.js
+++ b/src/arithmetic.js
@@ -54,12 +54,10 @@ function shuntingYard(text) {
   const queue = [];
 
   const tokens = text.split(tokenizer);
-  console.log(tokens);
 
   while (tokens.length > 0) {
     const token = tokens.shift();
     if (!token) continue;
-    console.log(token, stack, queue);
 
     if (isOperator(token)) {
       while (shouldPopOperator(token, stack[0])) {
@@ -155,7 +153,7 @@ const noWhitespace = /\s/g;
 
 // Variables are not replaced if the next non-whitespace character is a '('
 // e.g. max(5 + max)
-// the first max would not be replaced as it is a function
+// the first max would not be replaced as it is a function not a variable
 const buildVariableReplacer = (key) => new RegExp(`${key}(?!\\s*\\()`, 'g');
 
 export function runArithmetic(formulaText, values = {}) {
@@ -175,7 +173,7 @@ export function runArithmetic(formulaText, values = {}) {
   // strip out all whitespace
   const strippedText = valuedText.replace(noWhitespace, '');
 
-  // convert all characters to lowercase
+  // make sure that functions are case insensitive
   const lowercaseText = strippedText.toLowerCase();
 
   // then replace the unary minus with a 'u' so we can

--- a/src/arithmetic.js
+++ b/src/arithmetic.js
@@ -75,6 +75,7 @@ function shuntingYard(text) {
       while (shouldPopOperator(token, stack[0])) {
         queue.push(stack.shift());
       }
+      if (stack[0] !== '(' || !FUNCTION_NAMES.includes(stack[1])) throw new Error('Incorrect function call');
       continue;
     }
     if (token === ')') {
@@ -173,6 +174,7 @@ export function runArithmetic(formulaText, values = {}) {
   // strip out all whitespace
   const strippedText = valuedText.replace(noWhitespace, '');
 
+  if (strippedText.match(/([(,],)|(,\))/g)) throw new Error('Leading or trailing comma detected');
   // make sure that functions are case insensitive
   const lowercaseText = strippedText.toLowerCase();
 

--- a/src/arithmetic.js
+++ b/src/arithmetic.js
@@ -176,16 +176,18 @@ export function runArithmetic(formulaText, values = {}) {
       throw new Error('Invalid value substitution');
     }
 
-    //TODO:
     valuedText = valuedText.replace(buildVariableReplacer(key), value);
   });
 
   // strip out all whitespace
   const strippedText = valuedText.replace(noWhitespace, '');
 
+  // convert all characters to lowercase
+  const lowercaseText = strippedText.toLowerCase();
+
   // then replace the unary minus with a 'u' so we can
   // handle it differently to subtraction in the tokeniser
-  const replacedText = replaceUnaryMinus(strippedText);
+  const replacedText = replaceUnaryMinus(lowercaseText);
 
   console.log(strippedText, replacedText);
 

--- a/src/arithmetic.js
+++ b/src/arithmetic.js
@@ -24,7 +24,7 @@
 
 import { isOperator, getPrecedence } from './symbols';
 
-const unaryRegex = /(^|[*()x/+\-u,])-/g;
+const unaryRegex = /(^|[*(x/+\-u,])-/g;
 function replaceUnaryMinus(text) {
   const replaced = text.replace(unaryRegex, (match, p1) => `${p1}u`);
   if (replaced !== text) {
@@ -124,6 +124,8 @@ function processQueue(queue) {
 
     // alias just in case
     x: () => operations['*'](),
+
+    // functions
     max: () => {
       let val = stack.pop();
       let max = -Infinity;
@@ -150,6 +152,8 @@ function processQueue(queue) {
     }
     throw new Error('Unexpected token', item);
   }
+  console.log(stack[0]);
+  if (stack.length > 1 || typeof stack[0] !== 'number') throw new Error('Unmatched parenthesis');
 
   return stack[0];
 }

--- a/src/arithmetic.js
+++ b/src/arithmetic.js
@@ -22,7 +22,9 @@
 // that, don't sweat! There're unit tests and you can validate that things
 // work over there.
 
-import { isOperator, getPrecedence, FUNCTION_NAMES } from './symbols';
+import {
+  isOperator, getPrecedence, FUNCTION_NAMES, isFunctionToken,
+} from './symbols';
 
 const unaryRegex = /(^|[*(x/+\-u,])-/g;
 function replaceUnaryMinus(text) {
@@ -64,7 +66,7 @@ function shuntingYard(text) {
         queue.push(stack.shift());
       }
       stack.unshift(token);
-      if (FUNCTION_NAMES.includes(token)) queue.push('END_ARGS');
+      if (isFunctionToken(token)) queue.push('END_ARGS');
       continue;
     }
     if (token === '(') {
@@ -75,7 +77,10 @@ function shuntingYard(text) {
       while (shouldPopOperator(token, stack[0])) {
         queue.push(stack.shift());
       }
-      if (stack[0] !== '(' || !FUNCTION_NAMES.includes(stack[1])) throw new Error('Incorrect function call');
+      if (!(stack[0] === '(' && isFunctionToken(stack[1]))) {
+        // A comma is ONLY valid when the next thing in the stack is the function call
+        throw new Error('Incorrect function call');
+      }
       continue;
     }
     if (token === ')') {
@@ -84,7 +89,7 @@ function shuntingYard(text) {
       }
       if (stack[0] === '(') {
         stack.shift();
-        if (FUNCTION_NAMES.includes(stack[0])) {
+        if (isFunctionToken(stack[0])) {
           queue.push(stack.shift());
         }
       } else {

--- a/src/arithmetic.js
+++ b/src/arithmetic.js
@@ -48,7 +48,7 @@ function shouldPopOperator(token, topOfStack) {
   return true;
 }
 
-const tokenizer = /([+\-*/()uxm,])/g;
+const tokenizer = /(\+|-|\*|\/|\(|\)|u|max|x|,)/g;
 
 function shuntingYard(text) {
   const stack = [];
@@ -69,7 +69,7 @@ function shuntingYard(text) {
       continue;
     }
     if (token === '(') {
-      if (stack[0] && stack[0] === 'm') {
+      if (stack[0] && stack[0] === 'max') {
         queue.push(token);
       }
       stack.unshift(token);
@@ -79,16 +79,6 @@ function shuntingYard(text) {
       while (shouldPopOperator(token, stack[0])) {
         queue.push(stack.shift());
       }
-      //TODO:
-      //stack.unshift(token);
-      // while (stack.length > 0 && stack[0] !== '(') {
-      //   queue.push(stack.shift());
-      // }
-      // if (stack[0] === '(') {
-      //   //stack.shift();
-      // } else {
-      //   throw new Error('Unmatched parenthesis');
-      // }
       continue;
     }
     if (token === ')') {
@@ -97,7 +87,7 @@ function shuntingYard(text) {
       }
       if (stack[0] === '(') {
         stack.shift();
-        if (stack[0] === 'm') {
+        if (stack[0] === 'max') {
           queue.push(stack.shift());
         }
       } else {
@@ -112,7 +102,7 @@ function shuntingYard(text) {
       continue;
     }
 
-    throw new Error('Unrecognised token');
+    throw new Error(`Unrecognised token: ${token}`);
   }
 
   while (stack.length > 0) {
@@ -134,7 +124,7 @@ function processQueue(queue) {
 
     // alias just in case
     x: () => operations['*'](),
-    m: () => {
+    max: () => {
       let val = stack.pop();
       let max = -Infinity;
       while (val !== '(') {
@@ -177,6 +167,7 @@ export function runArithmetic(formulaText, values = {}) {
       throw new Error('Invalid value substitution');
     }
 
+    //TODO:
     valuedText = valuedText.replace(new RegExp(key, 'g'), value);
   });
 
@@ -185,10 +176,8 @@ export function runArithmetic(formulaText, values = {}) {
 
   // then replace the unary minus with a 'u' so we can
   // handle it differently to subtraction in the tokeniser
-  const replacedText = replaceUnaryMinus(strippedText)
-    .replace('max', 'm')
-    .replace('max', 'm')
-    .replace('max', 'm');
+  const replacedText = replaceUnaryMinus(strippedText);
+
   console.log(strippedText, replacedText);
 
   // then create a postfix queue using the shunting yard algorithm

--- a/src/arithmetic.js
+++ b/src/arithmetic.js
@@ -43,7 +43,6 @@ function shouldPopOperator(token, topOfStack) {
   if (topOfStack === '(') return false;
   const topPrecedence = getPrecedence(topOfStack);
   const tokenPrecedence = getPrecedence(token);
-  console.log(token, topOfStack, tokenPrecedence, topPrecedence);
   if (topPrecedence < tokenPrecedence) return false;
   return true;
 }
@@ -59,7 +58,6 @@ function shuntingYard(text) {
   while (tokens.length > 0) {
     const token = tokens.shift();
     if (!token) continue;
-    console.log(token, stack, queue);
 
     if (isOperator(token)) {
       while (shouldPopOperator(token, stack[0])) {
@@ -108,7 +106,6 @@ function shuntingYard(text) {
   while (stack.length > 0) {
     queue.push(stack.shift());
   }
-  console.log(queue);
 
   return queue;
 }
@@ -134,14 +131,12 @@ function processQueue(queue) {
         if (stack.length === 0) throw new Error('oop');
         val = stack.pop();
       }
-      console.log(val);
       return max;
     },
   };
 
   while (queue.length > 0) {
     const item = queue.shift();
-    console.log(queue, stack, item);
     if (typeof item === 'number' || item === '(') {
       stack.push(item);
       continue;
@@ -152,7 +147,6 @@ function processQueue(queue) {
     }
     throw new Error('Unexpected token', item);
   }
-  console.log(stack[0]);
   if (stack.length > 1 || typeof stack[0] !== 'number') throw new Error('Unmatched parenthesis');
 
   return stack[0];
@@ -188,8 +182,6 @@ export function runArithmetic(formulaText, values = {}) {
   // then replace the unary minus with a 'u' so we can
   // handle it differently to subtraction in the tokeniser
   const replacedText = replaceUnaryMinus(lowercaseText);
-
-  console.log(strippedText, replacedText);
 
   // then create a postfix queue using the shunting yard algorithm
   const queue = shuntingYard(replacedText);

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -35,7 +35,7 @@ export function getVariables(formulaText) {
   const variables = formulaText
     // Replace the alternate multiplication symbol 'x' with a non-alphanumeric character
     .replace(/(^|\W)x(\W|$)/, ' ')
-    // Replace functions
+    // Replace functions with a non-alphanumeric character
     .replace(/max\s*\(/, ' ')
     .split(/[+-/*() ]/g)
     .filter((v) => v !== '' && Number.isNaN(Number(v)));

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -6,11 +6,13 @@
  */
 
 export function isOperator(token) {
-  return ['+', '-', '/', '*', 'x', 'u'].includes(token);
+  return ['+', '-', '/', '*', 'x', 'u', 'm'].includes(token);
 }
 
 export function getPrecedence(operator) {
   switch (operator) {
+    case 'm':
+      return 5;
     case 'u':
       return 4;
     case '*':
@@ -20,6 +22,8 @@ export function getPrecedence(operator) {
     case '+':
     case '-':
       return 2;
+    case ',':
+      return 1;
     default:
       throw new Error('Invalid operator');
   }
@@ -29,8 +33,9 @@ export function getVariables(formulaText) {
   const variables = formulaText
     // Replace the alternate multiplication symbol 'x' with a non-alphanumeric character
     .replace(/(^|\W)x(\W|$)/, ' ')
+    .replace(/(^|\W)max(\W|$)/, ' ')
     .split(/[+-/*() ]/g)
-    .filter(v => v !== '' && Number.isNaN(Number(v)));
+    .filter((v) => v !== '' && Number.isNaN(Number(v)));
 
   return [...new Set(variables)];
 }

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -26,8 +26,6 @@ export function getPrecedence(operator) {
     case '+':
     case '-':
       return 2;
-    case ',':
-      return 1;
     default:
       throw new Error('Invalid operator');
   }

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -36,7 +36,7 @@ export function getVariables(formulaText) {
     // Replace the alternate multiplication symbol 'x' with a non-alphanumeric character
     .replace(/(^|\W)x(\W|$)/, ' ')
     // Replace functions with a non-alphanumeric character
-    .replace(/max\s*\(/, ' ')
+    .replace(new RegExp(`${FUNCTION_NAMES.join('|')}\\s*\\(`, 'g'), ' ')
     .split(/[+-/*() ]/g)
     .filter((v) => v !== '' && Number.isNaN(Number(v)));
 

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -6,12 +6,12 @@
  */
 
 export function isOperator(token) {
-  return ['+', '-', '/', '*', 'x', 'u', 'm'].includes(token);
+  return ['+', '-', '/', '*', 'x', 'u', 'max'].includes(token);
 }
 
 export function getPrecedence(operator) {
   switch (operator) {
-    case 'm':
+    case 'max':
       return 5;
     case 'u':
       return 4;
@@ -33,7 +33,7 @@ export function getVariables(formulaText) {
   const variables = formulaText
     // Replace the alternate multiplication symbol 'x' with a non-alphanumeric character
     .replace(/(^|\W)x(\W|$)/, ' ')
-    .replace(/(^|\W)max(\W|$)/, ' ')
+    .replace(/max\s*\(/, ' ')
     .split(/[+-/*() ]/g)
     .filter((v) => v !== '' && Number.isNaN(Number(v)));
 

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -5,14 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+export const FUNCTION_NAMES = ['max'];
+
 export function isOperator(token) {
-  return ['+', '-', '/', '*', 'x', 'u', 'max'].includes(token);
+  return ['+', '-', '/', '*', 'x', 'u'].includes(token) || FUNCTION_NAMES.includes(token);
 }
 
 export function getPrecedence(operator) {
+  if (FUNCTION_NAMES.includes(operator)) return 5;
+
   switch (operator) {
-    case 'max':
-      return 5;
     case 'u':
       return 4;
     case '*':
@@ -33,6 +35,7 @@ export function getVariables(formulaText) {
   const variables = formulaText
     // Replace the alternate multiplication symbol 'x' with a non-alphanumeric character
     .replace(/(^|\W)x(\W|$)/, ' ')
+    // Replace functions
     .replace(/max\s*\(/, ' ')
     .split(/[+-/*() ]/g)
     .filter((v) => v !== '' && Number.isNaN(Number(v)));

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -7,12 +7,14 @@
 
 export const FUNCTION_NAMES = ['max'];
 
+export const isFunctionToken = (token) => FUNCTION_NAMES.includes(token);
+
 export function isOperator(token) {
-  return ['+', '-', '/', '*', 'x', 'u'].includes(token) || FUNCTION_NAMES.includes(token);
+  return ['+', '-', '/', '*', 'x', 'u'].includes(token) || isFunctionToken(token);
 }
 
 export function getPrecedence(operator) {
-  if (FUNCTION_NAMES.includes(operator)) return 5;
+  if (isFunctionToken(operator)) return 5;
 
   switch (operator) {
     case 'u':


### PR DESCRIPTION
Unfortunately, given we require max to take a variable number of arguments, the algorithm supplied on wikipedia was not appropriate: https://en.wikipedia.org/wiki/Shunting-yard_algorithm#The_algorithm_in_detail.

This was also a valuable resource: https://blog.kallisti.net.nz/2008/02/extension-to-the-shunting-yard-algorithm-to-allow-variable-numbers-of-arguments-to-functions/

Essentially, it converts `max(1, 2 + 2 )` to ` END_ARGS 1 2 2 + max`
The other option as specified in the link above was `max(1, 2 + 2 )` to ` 1 2 2 + 2 max` (where the 2 next to the max is the number of arguments it has)